### PR TITLE
Update digitaloceanmodule.php

### DIFF
--- a/digitaloceanmodule.php
+++ b/digitaloceanmodule.php
@@ -755,6 +755,8 @@ class Digitaloceanmodule extends Module
             );
             $this->Input->setErrors($fa);
         }
+        
+        $params = $vars;// Fix for front-end ordering
 
         if ($vars['use_module'] == "true") {
             $sshkey_result = $api->getPostResults("account/keys", $ssh_key);


### PR DESCRIPTION
if ($vars['use_module'] == "true") is not called until cron is run so all fields are returned as NULL. Populating $params with $vars fixes this issue.